### PR TITLE
Add function to detect network device roots

### DIFF
--- a/backend/lib/bottleneck.ts
+++ b/backend/lib/bottleneck.ts
@@ -10,7 +10,7 @@ class Singleton {
       this.logger = logger;
 
       Singleton.instance = new Bottleneck.Group({
-        maxConcurrent: 5,
+        maxConcurrent: 10,
         minTime: 200,
         highWater: 1000,
       });

--- a/backend/services/device.service.ts
+++ b/backend/services/device.service.ts
@@ -31,7 +31,9 @@ import MerakiRootCause from "../types";
 export default class DevicesService extends Moleculer.Service {
   @Action({
     rest: "GET /organizations/:orgId/devices/statuses",
-    cache: true,
+    cache: {
+      ttl: 1000 * 60 * 5,
+    },
     params: schema<MerakiRootCause.IOrganizationId>(),
   })
   async statuses(
@@ -42,7 +44,9 @@ export default class DevicesService extends Moleculer.Service {
 
   @Action({
     rest: "GET /organizations/:orgId/devices/inventory",
-    cache: true,
+    cache: {
+      ttl: 1000 * 60 * 5,
+    },
     params: schema<MerakiRootCause.IOrganizationId>(),
   })
   async inventory(
@@ -92,5 +96,17 @@ export default class DevicesService extends Moleculer.Service {
     );
 
     return extract(info);
+  }
+
+  @Action({
+    cache: {
+      ttl: 1000 * 60 * 5,
+    },
+    params: schema<MerakiRootCause.IOrganizationId & { serial: string }>(),
+  })
+  async uplinks(
+    ctx: Context<MerakiRootCause.IOrganizationId & { serial: string }>,
+  ): Promise<MerakiRootCause.IUplink[]> {
+    return this._get(ctx, `devices/${ctx.params.serial}/uplink`);
   }
 }

--- a/backend/services/networks/methods/topology.ts
+++ b/backend/services/networks/methods/topology.ts
@@ -1,5 +1,5 @@
-import { partition, chain, without } from "lodash";
-import MerakiRootCause from "../../..//types";
+import { partition, chain, without, find, filter, each } from "lodash";
+import MerakiRootCause from "../../../types";
 
 function getDegradedFirewallSerials(
   firewalls: MerakiRootCause.IDeviceSummary[],
@@ -12,10 +12,37 @@ function getDegradedFirewallSerials(
   );
   return chain(offlineFirewalls)
     .filter(
-      (firewall) => without(onlineFirewallSerials, firewall.serial).length,
+      (firewall) => without(onlineFirewallSerials, firewall.serial).length > 0,
     )
     .map("serial")
     .value();
 }
 
-export { getDegradedFirewallSerials };
+function detectRoots(networkDevices: MerakiRootCause.IDeviceSummary[]) {
+  const roots: MerakiRootCause.IDeviceSummary[] = [];
+
+  networkDevices.forEach((networkDevice) => {
+    if (networkDevice.neighbors) {
+      each(
+        filter(
+          networkDevice.neighbors,
+          (neighbor) => neighbor.mac !== networkDevice.mac, // filter circles to itself
+        ),
+        (neighbor) => {
+          // is there a neighbor which is not part of the current network?
+          // if yes, we consider this device as a root
+          if (!find(networkDevices, { mac: neighbor.mac })) {
+            roots.push(networkDevice);
+            return false; // break loop
+          }
+
+          return true;
+        },
+      );
+    }
+  });
+
+  return roots;
+}
+
+export { getDegradedFirewallSerials, detectRoots };

--- a/backend/types/index.d.ts
+++ b/backend/types/index.d.ts
@@ -7,7 +7,6 @@ declare namespace MerakiRootCause {
     claimedAt: string;
     publicIp?: any;
     name: string;
-    [propName: string]: any;
   }
 
   interface IStatus {
@@ -22,10 +21,12 @@ declare namespace MerakiRootCause {
     wan1Ip?: any;
     wan2Ip?: any;
     lanIp?: any;
-    neighbors?: INeighbor[];
   }
 
-  export interface IDeviceSummary extends IInventory, IStatus {}
+  export interface IDeviceSummary extends IInventory, IStatus {
+    neighbors?: INeighbor[];
+    uplinks?: IUplink[];
+  }
 
   export interface INetwork {
     id: string;
@@ -119,6 +120,16 @@ declare namespace MerakiRootCause {
     };
     nodes: ITopologyNode[];
     edges: ITopologyEdge[];
+  }
+
+  export interface IUplink {
+    interface: string;
+    status: string;
+    ip: string;
+    gateway: string;
+    publicIp: string;
+    dns: string;
+    usingStaticIp: boolean;
   }
 }
 


### PR DESCRIPTION
Originally we took all firewalls as network roots. This PR uses a more sophisticated approach and adds the invers-neighbor-lookup feature as well.  